### PR TITLE
Fixes enventual conflicts when building multiple images at once

### DIFF
--- a/bundles/runner/Dockerfile.tpl
+++ b/bundles/runner/Dockerfile.tpl
@@ -4,7 +4,7 @@ FROM docker.polyconseil.fr/bundle-base:${grocker_version}
 ADD 00_install_package.sh /tmp/00_install_package.sh
 ADD 02_entrypoint.py /tmp/02_entrypoint.py
 ADD templates/ /tmp/templates/
-ADD output/ /tmp/output/
+ADD output/${build_id} /tmp/output/
 ADD scripts/ /tmp/scripts/
 
 RUN /tmp/00_install_package.sh


### PR DESCRIPTION
Project name and version are now appended to the output_dir

``` bash
(grocker)[vperron@M]<~/dev/grocker> ll bundles/runner/output/                                                            
total 12K
drwxr-x--- 2 vperron vperron 4,0K mai    4 18:26 autoslave-2.74.0.dev2015050404466
drwxr-x--- 2 vperron vperron 4,0K mai    4 18:17 chargealot-0.30.0.dev2015050401505
drwxr-x--- 2 vperron vperron 4,0K mai    4 18:26 milborne-0.4.0.dev2015050400343
```
