### PR TITLE
runner: adds a configuration to set the outgoing smtp host

### DIFF
--- a/bundles/runner/02_entrypoint.py
+++ b/bundles/runner/02_entrypoint.py
@@ -133,6 +133,8 @@ def setup_mail_relay():
     }
 
     templatize('ssmtp.conf', os.path.join('~', 'etc', 'ssmtp.conf'), context)
+    templatize('django_smtp_settings.ini', os.path.join(DJANGO_SETTINGS_PATH,
+        '40_smtp_settings.ini'), get_context())
 
 
 def setup_logging(enable_colors):

--- a/bundles/runner/templates/django_smtp_settings.ini
+++ b/bundles/runner/templates/django_smtp_settings.ini
@@ -1,0 +1,2 @@
+[email]
+host = ${smtp_server}


### PR DESCRIPTION
Automagically configure the smtp server as the host's one
