### PR TITLE
Allow for non django project to be grockerized

### DIFF
--- a/bundles/runner/01_setup_cron.sh
+++ b/bundles/runner/01_setup_cron.sh
@@ -6,7 +6,7 @@ source /opt/bundle/base.env
 source ${USER_HOME}/etc/config.env
 
 # Copy crontabs to root, ensure permissions
-CRONTAB_FILE=$(${USER_HOME}/app/bin/python -c "import pkg_resources; print(pkg_resources.resource_filename('${PROJECT_NAME}', 'crontab'))")
+CRONTAB_FILE=$(${USER_HOME}/app/bin/python -c "import pkg_resources; print(pkg_resources.resource_filename('${PACKAGE_NAME}', 'crontab'))") || true
 if [ -f "${CRONTAB_FILE}" ]; then
     cat ${CRONTAB_FILE} | \
     sed -e "s@ www-data @ @" | \

--- a/bundles/runner/02_entrypoint.py
+++ b/bundles/runner/02_entrypoint.py
@@ -25,7 +25,7 @@ import textwrap
 
 BLUE_HOME = '/home/blue'
 CONFIG_MOUNT_POINT = '/config'
-DJANGO_SETTINGS_PATH = os.path.join(BLUE_HOME, 'django_config')
+DJANGO_SETTINGS_PATH = os.path.join(BLUE_HOME, 'app_config')
 ENV_CONFIG = os.path.join(BLUE_HOME, 'etc', 'config.env')
 LOG_DIR = os.path.join(BLUE_HOME, 'logs')
 RUN_DIR = os.path.join(BLUE_HOME, 'run')
@@ -225,7 +225,10 @@ def main():
     setup_logging(not args.disable_colors)
     setup_environment()
     setup_app()
-    setup_mail_relay()
+    try:
+        setup_mail_relay()
+    except Exception:
+        logging.getLogger(__name__).exception("Cannot setup mail relay")
 
     dispatch(args.args)
 

--- a/grocker.py
+++ b/grocker.py
@@ -43,6 +43,7 @@ RUNNER_ENV_FILE_TPL = """
 def main():
     args = builder_arg_parser(sys.argv[1:])
     project, version = args.package.split('==')
+    project = project.replace("[", "-").replace("]", "")
     build_id = '{0}-{1}'.format(project, version)
 
     setup_logging(not args.no_colors)
@@ -101,7 +102,7 @@ def builder_arg_parser(argv):
 
 
 def _versioned_package(value):
-    if not re.match(r'\w(\w|-)+==\d+.\d+.\d+', value):
+    if not re.match(r'\w(\w|-)+(\[\w*\])?==\d+.\d+.\d+', value):
         raise argparse.ArgumentTypeError("Do not match <name>==<x>.<y>.<z> pattern.")
     return value
 


### PR DESCRIPTION
This commit uses a lot of hacks to be able to dockerize a python package which uses 'extra'.

example:

```
   benoit@omniscience ~/Projects/blue/grocker (bcz/allow_pure_python_projets) $ make build PACKAGE="bluelink[pop]" VERSION=0.8.0.dev2015070300015 PYTHON_VERSION=3.4
```
