### PR TITLE
Fix grocker ssh known hosts

### DIFF
--- a/bundles/runner/02_entrypoint.py
+++ b/bundles/runner/02_entrypoint.py
@@ -25,6 +25,7 @@ import textwrap
 
 BLUE_HOME = '/home/blue'
 CONFIG_MOUNT_POINT = '/config'
+SSH_KNOWN_HOSTS_FILE = 'ssh-known-hosts'
 DJANGO_SETTINGS_PATH = os.path.join(BLUE_HOME, 'app_config')
 ENV_CONFIG = os.path.join(BLUE_HOME, 'etc', 'config.env')
 LOG_DIR = os.path.join(BLUE_HOME, 'logs')
@@ -123,6 +124,20 @@ def setup_app():
             src=os.path.join(si_mounted_config_dir, filename),
             dst=os.path.join(DJANGO_SETTINGS_PATH, filename),
         )
+
+    # Copy ssh-known-hosts
+    dst_ssh_dir = os.path.join(BLUE_HOME, '.ssh')
+    dst_ssh_known_hosts = os.path.join(dst_ssh_dir, 'known_hosts')
+    src_ssh_known_hosts = os.path.join(CONFIG_MOUNT_POINT, SSH_KNOWN_HOSTS_FILE)
+
+    create_directory(dst_ssh_dir)
+    os.chmod(dst_ssh_dir, 448)  # 0700 octal
+    if os.path.exists(src_ssh_known_hosts):
+        shutil.copy(
+            src=src_ssh_known_hosts,
+            dst=dst_ssh_known_hosts,
+        )
+        os.chmod(dst_ssh_known_hosts, 384)  # 0600 octal
 
 
 def setup_mail_relay():

--- a/docs/usage/run.rst
+++ b/docs/usage/run.rst
@@ -43,6 +43,7 @@ de configuration de base est fourni par l'image *Grocker*, celui-ci a une priori
 surcharger en utilisant des fichiers de priorité supérieure::
 
     config
+    ├── ssh-known-hosts
     └── app
         ├── 10_low_priority.ini
         ├── 50_default_settings.ini
@@ -101,11 +102,16 @@ Comment lancer un service ?
         -v ${MEDIA_DIR}:/media:rw \
         -v ${SCRIPT_DIR}:/scripts:rw \
         -v /dev/log:dev/log:rw \
-        -p ${PORT}:8080
-        -p ${SUPERVISION_PORT}:8081
+        -p ${PORT}:8080 \
+        -p ${SUPERVISION_PORT}:8081 \
         -ti \
         ${IMAGE} \
         start ${SERVICE}
+
+.. note::
+  
+  Le flag '-ti' ci-dessus n'est la plupart du temps pas nécessaire au lancement d'un service;
+  il permet surtout d'interagir (avec un flux stdin) avec la machine virtualisée.
 
 
 .. _run-scripts:


### PR DESCRIPTION
A /config/ssh-known-hosts file can be mounted to the image,
the entrypoint will use it to enable the application to connect
to trusted external services.

References #34 
