### PR TITLE
pip: use host extra pypi indexes

### DIFF
--- a/bundles/compiler/01_compile.py
+++ b/bundles/compiler/01_compile.py
@@ -27,6 +27,7 @@ def main(argv):
     guest_config = configparser.ConfigParser()
     guest_config.add_section('global')
     guest_config.set('global', 'index-url', host_config.get('global', 'index-url'))
+    guest_config.set('global', 'extra-index-url', host_config.get('global', 'extra-index-url'))
     guest_config.set('global', 'wheel-dir', output_dir)
     guest_config.set('global', 'find-links', output_dir)
 


### PR DESCRIPTION
Our new pypi server does not have all packages mirrored. Often, a package is missing, preventing from building the image.

We can use several indexes to download the packages.
