### PR TITLE
Ffreitag/nginx is backported

### DIFF
--- a/bundles/base/00_apt_config.sh
+++ b/bundles/base/00_apt_config.sh
@@ -15,3 +15,4 @@ APT::Install-Suggests=false;
 EOF
 
 # TODO: Setup private Debian repo
+# https://github.com/Polyconseil/devtools/issues/103


### PR DESCRIPTION
There is no need to setup debian packages for nginx, it has been backported for wheezy and jessie.

cf. https://wiki.debian.org/Nginx

Plus: Retrieving the key isn't very reliable, network timeouts often occur, resulting in a failed build.
