### PR TITLE
Add grocker version to images tags

### DIFF
--- a/grocker.py
+++ b/grocker.py
@@ -78,7 +78,7 @@ def main():
         run(
             'docker', 'build',
             '--force-rm=true', '--rm=true',
-            '-t', '{0}/{1}:{2}'.format(REGISTRY_FQDN, project, version),
+            '-t', '{0}/{1}:{2}-{3}'.format(REGISTRY_FQDN, project, version, __version__),
             'bundles/runner/.'
         )
 


### PR DESCRIPTION
Since we want to add grocker version in image name, why not add it from the start ?

Maybe we only want to add grocker version when the package version in not a dev version. I can change it this way.
