### PR TITLE
Add grocker version to package tag

### DIFF
--- a/grocker.py
+++ b/grocker.py
@@ -78,7 +78,7 @@ def main():
         run(
             'docker', 'build',
             '--force-rm=true', '--rm=true',
-            '-t', '{0}/{1}:{2}'.format(REGISTRY_FQDN, project, version),
+            '-t', '{0}/{1}:{2}-{3}'.format(REGISTRY_FQDN, project, version, __version__),
             'bundles/runner/.'
         )
 


### PR DESCRIPTION
Dans mon utilisation de grocker (pour releaser autoslave) je me rends compte que j'ai systématiquement besoin d'ajouter la version de grocker après la création de l'image.

Si c'est la règle pour toutes nos images docker, est-ce qu'on peut envisager que ce soit fait automatiquement ?
