### PR TITLE
uwsgi: changing default max_requests

### DIFF
--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -22,7 +22,7 @@ single-interpreter = true
 
 buffer-size = 8192
 harakiri = 610
-max-requests = 200
+max-requests = 5000
 reload-on-as = 1536
 reload-on-rss = 1024
 


### PR DESCRIPTION
This PR aims to reduce the number of response-time spikes when a new worker spawns.
