### PR TITLE
Makefile: Add Grocker version to Docker image tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ BLUESOLUTIONS_IMAGES := $(shell docker images | grep '^bluesolutions' | awk '{pr
 BLUE_REGISTRY_IMAGES := $(shell docker images | grep '^docker\.polydev\.blue' | awk '{print $$3}')
 
 VERSION ?= $(shell pypi-version $(PACKAGE) 2>/dev/null |grep latest_dev | cut -d' ' -f 2)
-GROCKER_VERSION = $(shell ./grocker.py --version | rev |cut -d" " -f1 | rev)
+GROCKER_VERSION = $(shell ./grocker.py --version | rev | cut -d" " -f1 | rev)
 
 # Tasks
 #======


### PR DESCRIPTION
Since c17f6a874, the version of Grocker is appended to the image tag. We
should do the same when we run `docker push`.
# 

C'est un peu moche, car on génère le tag à deux endroits : dans le code de Grocker et dans le Makefile. En fait, je verrais plutôt des commandes du genre `grocker build` et `grocker push` plutôt que des règles de Makefile. Mais s'il y a une v2 de Grocker en cours, c'est peut-être pas pertinent de modifier la commande.
