### PR TITLE
Syslog: Use TCP instead of socket.

### DIFF
--- a/bundles/runner/02_entrypoint.py
+++ b/bundles/runner/02_entrypoint.py
@@ -75,6 +75,7 @@ def get_context():  # TODO: replace by ad-hoc context in function ?
         uwsgi_workers = int(os.environ.get('UWSGI_WORKERS', 10))
     except ValueError:
         uwsgi_workers = 10
+    rsyslog_host = os.environ.get('RSYSLOG_HOST', get_host_ip()) #TODO: user input validation. import ipaddress ?
     if python_major == '3':
         uwsgi_plugin_name = '{}{}'.format(uwsgi_plugin_name, python_major)
 
@@ -85,6 +86,7 @@ def get_context():  # TODO: replace by ad-hoc context in function ?
         'project_name_upper': os.environ['PROJECT_NAME'].upper(),
         'uwsgi_plugin_name': uwsgi_plugin_name,
         'uwsgi_workers': uwsgi_workers,
+        'rsyslog_host': rsyslog_host,
         'venv': VENV,
         'http_proxy': os.environ.get('http_proxy', ''),
         'https_proxy': os.environ.get('https_proxy', ''),

--- a/bundles/runner/templates/nginx.conf
+++ b/bundles/runner/templates/nginx.conf
@@ -38,8 +38,8 @@ http {
     # Logging Settings
     ##
 
-    access_log syslog:server=unix:/dev/log,facility=local7,tag=grocker_nginx;
-    error_log syslog:server=unix:/dev/log,facility=local7,tag=grocker_nginx warn;
+    access_log syslog:server=${rsyslog_host},facility=local7,tag=grocker_nginx,severity=info;
+    error_log syslog:server=${rsyslog_host},facility=local7,tag=grocker_nginx warn;
 
     ##
     # Temp paths

--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -9,10 +9,10 @@ pythonpath = /home/blue
 home = /home/blue/app
 
 socket = /tmp/uwsgi.sock
-plugin = ${uwsgi_plugin_name},syslog
+plugin = ${uwsgi_plugin_name},rsyslog
 
 # redirect logs to /dev/log. uwsgi is the prefix in the log line
-logger = syslog:grocker_uwsgi,local6
+logger = rsyslog:${rsyslog_host},grocker_uwsgi,local6
 
 master = true
 workers = ${uwsgi_workers}


### PR DESCRIPTION
Logging through a socket is risky : the container's health and ability to log is dependant on host's syslog-ng availability.
This allows us to remove a potential point of failure; furthermore it allows more flexibility for log management.
