### PR TITLE
nginx-compress: enable compression for ie6 and improve gzip config

### DIFF
--- a/bundles/runner/templates/nginx.conf
+++ b/bundles/runner/templates/nginx.conf
@@ -55,7 +55,12 @@ http {
     ##
 
     gzip on;
-    gzip_disable "msie6";
+#   gzip_disable "msie6";
+    gzip_min_length 500;
+    gzip_comp_level 5;
+    gzip_static on;
+    gzip_vary on;
+    gzip_types text/plain text/xml text/css text/javascript application/xml application/x-javascript;
 
     server {
         listen      8080;


### PR DESCRIPTION
Bonjour,
L'équipe Ingé essaie de réduire l'utilisation de la BP dans les infra dockerisées.
Or, les terminaux dans les voitures et certains PDA utilisent encore IE6.

**gzip_disable "msie6"** désactive la compression si le user agent commence par "**Mozilla/4.0 (compatible; MSIE 6.0**" sauf s'il contient aussi SV1. 
CF : http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable 
Cela permet d'éviter des bugs avec les IE6 pré-SP2

Le SV1 est un ajout de MS qui indique que le SP2 est installé sur la machine. De notre côté ça ne nous sert pas à grand chose car s'il s'agit d'un SP3 et que le SP2 n'a jamais été installé, il semble que le petit ajout "**SV1**" ne soit pas présent (ce qui empêche à tort la compression).

Cette ligne est déjà commentée sur le nginx de la machine hôte.

La suite des paramètres améliore la gestion du gzip, par exemple en mettant une taille de paquet minimale et en améliorant le taux de compression.

Gros bisous !

chpat
