### PR TITLE
Fix syslog priority

### DIFF
--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -11,8 +11,11 @@ home = /home/blue/app
 socket = /tmp/uwsgi.sock
 plugin = ${uwsgi_plugin_name},rsyslog
 
-# redirect logs to /dev/log. uwsgi is the prefix in the log line
-logger = rsyslog:${rsyslog_host},grocker_uwsgi,local6
+# Redirect logs to default gateway
+# grocker_uwsgi is the syslog tag
+# 182 is the syslog priority: local6.info
+# See available priorities: http://www.solarwinds.com/documentation/en/flarehelp/ncm/content/syslogpriorities.htm
+logger = rsyslog:${rsyslog_host},grocker_uwsgi,182
 
 master = true
 workers = ${uwsgi_workers}


### PR DESCRIPTION
Uwsgi use syslog priority (Facility \* 8 + Severity) to define facility and severity.

According to http://www.solarwinds.com/documentation/en/flarehelp/ncm/content/syslogpriorities.htm we define syslog facility to local6.info (182).
