### PR TITLE
uwsgi: lowering reload-on-as|rss parameters

### DIFF
--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -26,8 +26,8 @@ single-interpreter = true
 buffer-size = 8192
 harakiri = 610
 max-requests = 5000
-reload-on-as = 1536
-reload-on-rss = 1024
+reload-on-as = 1024
+reload-on-rss = 512
 
 stats-http = 127.0.0.1:8082
 # FIXME: reload-on-as, reload-on-rss, harakiri maybe too high


### PR DESCRIPTION
Autolib OPS containers ate over 4GB RAM per node in production. We need to lower allocated memory to uwsgi-workers to avoid swapping.
We have allocated 6GB RAM per node, and are running 10 workers per node. 512 seems sensible enough.
