### PR TITLE
Use a fixed debian base image version

### DIFF
--- a/bundles/base/Dockerfile
+++ b/bundles/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:8.2
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
We must be sure we have the same debian version for each docker image.
Since debian jessie has already 2 subversions, I think we should use them
