### PR TITLE
uwsgi: lowering again reload-on-rss parameters

### DIFF
--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -27,7 +27,7 @@ buffer-size = 8192
 harakiri = 610
 max-requests = 5000
 reload-on-as = 1024
-reload-on-rss = 512
+reload-on-rss = 400
 
 stats-http = 127.0.0.1:8082
 # FIXME: reload-on-as, reload-on-rss, harakiri maybe too high


### PR DESCRIPTION
Hello !

Comme vu avec fbochu, le paramètre reload-on-rss est encore légèrement trop élevé et les machines eqxprdparops01-3 swap malgré le passage de 4 à 6Go de RAM.
La valeur 400 semble un bon compromis.

Pour rappel la valeur "initiale" (avant le passage à docker) était 220.

Cordialement,
