### PR TITLE
add telnet to base installed package

### DIFF
--- a/bundles/base/base.env
+++ b/bundles/base/base.env
@@ -10,6 +10,7 @@ SYS_DEPS="
     cron
     ssmtp
     less
+    netcat-traditional
     nginx
     python
     python3


### PR DESCRIPTION
en vrai on peut s'en sortir, mais bon.

```
blue@8efbea140756:/$ python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.socket(socket.AF_INET, socket.SOCK_STREAM)
<socket._socketobject object at 0x7f37cf1a70c0>
>>> s = _
>>> s.connect(('rabbitmq', 5672))
>>> s.send('AMQP') 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
socket.error: [Errno 104] Connection reset by peer
>>> 
```
