### PR TITLE
uwsgi: correct uwsgi-stats parameters

### DIFF
--- a/bundles/runner/templates/uwsgi.ini
+++ b/bundles/runner/templates/uwsgi.ini
@@ -29,5 +29,6 @@ max-requests = 5000
 reload-on-as = 1024
 reload-on-rss = 400
 
-stats-http = 127.0.0.1:8082
+stats = 127.0.0.1:8082
+stats-http = true
 # FIXME: reload-on-as, reload-on-rss, harakiri maybe too high


### PR DESCRIPTION
Hello,
Comme vu sur slack dev, uwsgi n'écoute pas sur son interface de stats en raison d'un paramètre incorrect.

Ce changement backport la conf de grocker2, proposé par fbochu.

Cordialement,
