### PR TITLE
nginx: enlarge your client body buffer

### DIFF
--- a/bundles/runner/templates/nginx.conf
+++ b/bundles/runner/templates/nginx.conf
@@ -28,6 +28,9 @@ http {
     # disable body size checks. Done in the VM
     client_max_body_size 0;
 
+    # allow larger than default 16k client body buffer
+    client_body_buffer_size 64k;
+
     server_names_hash_bucket_size 128;
     # server_name_in_redirect off;
 


### PR DESCRIPTION
Some webservices receive POST requests (SOAP XML) larger than the default 8k / 16k buffer; those request bodies need to be partially written to disk, which degrades performance - especially when done in a container.
This merge sets the **client_body_buffer_size** to 64k, which should be large enough for most requests.
