### PR TITLE
Allow to set docker entrypoint in run image

### DIFF
--- a/grocker/__main__.py
+++ b/grocker/__main__.py
@@ -53,6 +53,10 @@ def arg_parser():
         '-r', '--runtime', default=None, choices=('python2', 'python3'),
         help="runtime used to build and run this image.",
     )
+    parser.add_argument(  # precedence
+        '-e', '--entrypoint-name', default=None,
+        help="Docker entrypoint to use to run this image.",
+    )
     parser.add_argument(
         '--pip-conf', metavar='<file>', type=file_path_or_none_type, default=None,
         help="pip configuration file used to download dependencies (by default use pip config getter).",
@@ -149,6 +153,7 @@ def main(cli_args=None):
     config = parse_config(
         args.config,
         runtime=args.runtime,
+        entrypoint_name=args.entrypoint_name,
         pip_constraint=args.pip_constraint,
         docker_image_prefix=args.docker_image_prefix,
     )

--- a/grocker/builders.py
+++ b/grocker/builders.py
@@ -195,7 +195,10 @@ def build_runner_image(
             helpers.render_template(
                 os.path.join(build_dir, 'Dockerfile.j2'),
                 os.path.join(build_dir, 'Dockerfile'),
-                {'root_image_tag': root_image_tag},
+                {
+                    'root_image_tag': root_image_tag,
+                    'entrypoint_name': config['entrypoint_name'],
+                },
             )
             helpers.render_template(
                 os.path.join(build_dir, '.grocker.j2'),

--- a/grocker/resources/docker/runner-image/Dockerfile.j2
+++ b/grocker/resources/docker/runner-image/Dockerfile.j2
@@ -17,4 +17,4 @@ EXPOSE 8080 8081
 # Make the entry point run the compile script
 USER grocker
 WORKDIR /home/grocker
-ENTRYPOINT ["/home/grocker/app.venv/bin/grocker-runner"]
+ENTRYPOINT ["/home/grocker/app.venv/bin/{{ entrypoint_name }}"]

--- a/grocker/resources/grocker.yaml
+++ b/grocker/resources/grocker.yaml
@@ -38,3 +38,4 @@ runtime: python2
 pip_constraint:
 dependencies: []
 docker_image_prefix:
+entrypoint_name: grocker-runner

--- a/tests/resources/grocker-test-project/gtp/__init__.py
+++ b/tests/resources/grocker-test-project/gtp/__init__.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) Polyconseil SAS. All rights reserved.
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-__version__ = '1.0.1'

--- a/tests/resources/grocker-test-project/gtp/__main__.py
+++ b/tests/resources/grocker-test-project/gtp/__main__.py
@@ -32,5 +32,10 @@ def identity(content):
 def main():
     print(identity(sys.argv[1] if len(sys.argv) > 1 else 'Missing parameter !'))
 
+
+def custom():
+    msg = identity(sys.argv[1] if len(sys.argv) > 1 else 'Missing parameter !')
+    print('custom: %s' % msg)
+
 if __name__ == '__main__':
     main()

--- a/tests/resources/grocker-test-project/setup.py
+++ b/tests/resources/grocker-test-project/setup.py
@@ -5,16 +5,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from setuptools import setup, find_packages
 
-from gtp import __version__
-
-
 setup(
     name='grocker-test-project',
     description='Test project for Grocker',
     url='http://github.com/polyconseil/grocker',
     author='Polyconseil',
     author_email='TBD on first public release',
-    version=__version__,
+    version='1.0.3',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
         'zbarlight',  # dependency using C modules
@@ -24,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'grocker-runner = gtp.__main__:main',
+            'my-custom-runner = gtp.__main__:custom',
         ],
     },
 )


### PR DESCRIPTION
Some application already provide suitable entrypoint for Docker. In this
case, it's not necessary to redefine a setuptools entrypoint named
grocker-runner, we can just use the application provided entrypoint.

This will be useful for Bluelink.
