### PR TITLE
Use explicit Python version in runtime name

### DIFF
--- a/grocker/__main__.py
+++ b/grocker/__main__.py
@@ -50,7 +50,7 @@ def arg_parser():
         help='Grocker config file',
     )
     parser.add_argument(  # precedence
-        '-r', '--runtime', default=None, choices=('python2', 'python3'),
+        '-r', '--runtime', default=None,
         help="runtime used to build and run this image.",
     )
     parser.add_argument(  # precedence
@@ -162,6 +162,9 @@ def main(cli_args=None):
     logger = logging.getLogger('grocker' if __name__ == '__main__' else __name__)
 
     args.actions = clean_actions(args.actions)
+
+    if config['runtime'] not in config['system']['runtime']:
+        raise RuntimeError('Unknown runtime: %s', config['runtime'])
 
     docker_client = builders.docker_get_client()
     image_name = args.image_name or helpers.default_image_name(config['docker_image_prefix'], args.release)

--- a/grocker/resources/grocker.yaml
+++ b/grocker/resources/grocker.yaml
@@ -22,18 +22,18 @@ system:  # grocker internal configuration
     - nodejs-legacy
 
   runtime:  # dependencies needed for specified runtime
-    python2:
+    python2.7:
       - python: python-dev
       - libpython2.7
       - python-virtualenv
-    python3:
+    python3.4:
       - python3: python3-dev
       - libpython3.4
       - python3-virtualenv
 
 # There begin the project configuration (so all values below are use as default)
 
-runtime: python2
+runtime: python3.4
 # pip_constraint is optional
 pip_constraint:
 dependencies: []

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import re
 import subprocess
-import sys
 import textwrap
 import unittest
 import uuid
@@ -66,20 +65,21 @@ class BuildTestCase(unittest.TestCase):
         - libffi6: libffi-dev
         - libtiff5: libtiff5-dev
     """
+    runtime = None
 
     def run_grocker(self, release, command, cwd=None):
         image_name = 'grocker.test/{}'.format(uuid.uuid4())
-        runtime = 'python{}'.format(sys.version_info[0])
         try:
             subprocess.check_call(
                 [
                     'python', '-m', 'grocker',
                     '--image-name', image_name,
-                    '--runtime', runtime,
                     '--docker-image-prefix', 'docker.polydev.blue',
                     'dep', 'img',
                     release,
-                ],
+                ] + (
+                    ['--runtime', self.runtime] if self.runtime else []
+                ),
                 cwd=cwd,
             )
 
@@ -122,3 +122,7 @@ class BuildTestCase(unittest.TestCase):
         msg = 'Grocker build this successfully !'
         expected = 'custom: %s' % msg
         self.check(config, msg, expected)
+
+
+class BuildCustomRuntimeTestCase(BuildTestCase):
+    runtime = 'python2.7'


### PR DESCRIPTION
Debian Unstable support for now python 2.7, 3.4 and 3.5. We will not use
the unstable version of Debian, but we should be futur proof.
