### PR TITLE
Allow to define container volumes and ports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 Next version (not yet released)
 -------------------------------
 
+- Drop predefined exposed ports and volumes
 - tags: Rename ``grocker.step`` into ``grocker.image.kind``
 
 

--- a/grocker/__main__.py
+++ b/grocker/__main__.py
@@ -56,6 +56,14 @@ def arg_parser():
         '-e', '--entrypoint-name', default=None,
         help="Docker entrypoint to use to run this image.",
     )
+    parser.add_argument(  # precedence
+        '--volume', action='append', default=[], dest='volumes',
+        help="Container storage and configuration area.",
+    )
+    parser.add_argument(  # precedence
+        '--port', action='append', default=[], dest='ports',
+        help="Port on which a container will listen for connections."
+    )
     parser.add_argument(
         '--pip-conf', metavar='<file>', type=file_path_or_none_type, default=None,
         help="pip configuration file used to download dependencies (by default use pip config getter).",
@@ -165,6 +173,8 @@ def main():
         entrypoint_name=args.entrypoint_name,
         pip_constraint=args.pip_constraint,
         docker_image_prefix=args.docker_image_prefix,
+        volumes=args.volumes,
+        ports=args.ports,
     )
 
     loggers.setup(verbose=args.verbose)

--- a/grocker/builders.py
+++ b/grocker/builders.py
@@ -198,6 +198,8 @@ def build_runner_image(
                 {
                     'root_image_tag': root_image_tag,
                     'entrypoint_name': config['entrypoint_name'],
+                    'volumes': config['volumes'],
+                    'ports': config['ports'],
                 },
             )
             helpers.render_template(

--- a/grocker/helpers.py
+++ b/grocker/helpers.py
@@ -6,6 +6,7 @@ import contextlib
 import functools
 import hashlib
 import io
+import json
 import os.path
 import shutil
 import tempfile
@@ -45,8 +46,11 @@ def hash_list(l):
 
 
 def render_template(template_path, output_path, context):
+    env = jinja2.Environment()
+    env.filters['jsonify'] = json.dumps
+
     with io.open(template_path, encoding='utf-8') as template_file:
-        template = jinja2.Template(template_file.read())
+        template = env.from_string(template_file.read())
 
     output = template.render(**context)
 

--- a/grocker/resources/docker/runner-image/Dockerfile.j2
+++ b/grocker/resources/docker/runner-image/Dockerfile.j2
@@ -6,12 +6,9 @@ COPY . /tmp/grocker
 # always sync before running script to avoid "unable to execute /tmp/grocker/provision.sh: Text file busy"
 RUN sync; /bin/bash /tmp/grocker/provision.sh
 
-# Prepare the image to run the entry point
-VOLUME ["/media", "/scripts", "/config"]
-RUN ln -s /config /scripts /media /home/grocker/
-
-# Exposed ports
-EXPOSE 8080 8081
+# Ports and Volumes
+{% if ports %}EXPOSE{% for port in ports %} {{ port }}{% endfor %}{% endif %}
+{% if volumes %}VOLUME {{volumes | jsonify }}{% endif %}
 
 # Make the entry point run the compile script
 USER grocker

--- a/grocker/resources/grocker.yaml
+++ b/grocker/resources/grocker.yaml
@@ -34,8 +34,9 @@ system:  # grocker internal configuration
 # There begin the project configuration (so all values below are use as default)
 
 runtime: python3.4
-# pip_constraint is optional
-pip_constraint:
+pip_constraint: # pip_constraint is optional
+volumes: []
+ports: []
 dependencies: []
 docker_image_prefix:
 entrypoint_name: grocker-runner


### PR DESCRIPTION
Predefined ports and volumes are specific to our entry-point. We already
have an generic configuration file for our applications so those information
should be in this file not in the build chain.
