### PR TITLE
Fix builds on Travis-CI and ask for a specific version of Docker API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: python
 sudo: required
+dist: trusty
 python:
   - "2.7"
   - "3.4"
   - "3.5"
-services:
-  - docker
+#services:
+#  - docker
+before_install:
+    - sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+    - sudo add-apt-repository 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' -y
+    - sudo apt-get update
+    - sudo apt-get install -y -o Dpkg::Options::='--force-confnew' docker-engine
+
 install: pip install tox-travis pytest-travis-fold
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_install:
     - sudo apt-get install -y -o Dpkg::Options::='--force-confnew' docker-engine
 
 install: pip install tox-travis pytest-travis-fold
+before_script: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 script: tox

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,8 +4,7 @@ ChangeLog
 4.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Ask for a specific verison of the Docker API (1.21)
 
 4.0 (2016-07-20)
 ----------------

--- a/src/grocker/__init__.py
+++ b/src/grocker/__init__.py
@@ -7,4 +7,4 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution('grocker').version
 __copyright__ = '2015, Polyconseil'
 
-DOCKER_MIN_VERSION = '1.8.2'
+DOCKER_API_VERSION = '1.21'

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -177,10 +177,6 @@ def main():
         'image': image_name,
     }
 
-    logger.info('Checking prerequisites...')
-    if builders.is_docker_outdated(docker_client):
-        raise RuntimeError('Docker is outdated')
-
     wheels_volume_name = 'grocker-wheels-cache-{version}-{hash}'.format(
         version=__version__,
         hash=helpers.config_identifier(config),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -89,6 +89,7 @@ class BuildTestCase(unittest.TestCase):
             subprocess.check_call(
                 [
                     'python', '-m', 'grocker',
+                    '--docker-image-prefix', 'grocker',
                     '--image-name', image_name,
                     '--result-file', result_file_path,
                     'dep', 'img',


### PR DESCRIPTION
Builds fail on Travis-CI because the Docker server installed by default only support Docker API 1.20 and Grocker need a least Docker API 1.21 (for the volumes API).

I have also simplify the version checking by requiring a specific version of the API. Now, an error is raised when we ask a docker client and the API version is not compatible.