### PR TITLE
setup.py: Exclude docker-py 1.10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'docker-py',
+        'docker-py!=1.10.*',
         'Jinja2',
         'setuptools>=18.0.1',
         'pip>=7.1.2',


### PR DESCRIPTION
docker-py 1.10.x restrict requests version to 2.10.x and lower. request
2.11.0 have a bug with decode_unicode=True and streamed response but it
was fix in 2.11.1...