### PR TITLE
Add a sync call after chmod call to avoid an AUFS issue

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,7 @@ ChangeLog
 4.2 (unreleased)
 ----------------
 
+- Add a sync after chmod call to avoid an AUFS issue
 - Fix image search when repoTags is None and not an empty list
 
 

--- a/src/grocker/resources/docker/runner-image/provision.sh
+++ b/src/grocker/resources/docker/runner-image/provision.sh
@@ -34,6 +34,7 @@ function run_as_user() {  # script_or_function
         ${script_or_function}
     else
         chmod -R go+rX ${WORKING_DIR}  # Allow non-root user to use file in grocker temporary directory
+        sync  # sync before running script to avoid "unable to execute /tmp/grocker/provision.sh: Text file busy"
         sudo -u ${GROCKER_USER} $0  # Run this script with grocker user
         rm -r ${WORKING_DIR}  # clean up
     fi


### PR DESCRIPTION
The issue manifests itself with:

    + apt-get clean
    + run_as_user provision
    + local script_or_function=provision
    ++ whoami
    + '[' root == grocker ']'
    + chmod -R go+rX /tmp/grocker
    + sudo -u grocker /tmp/grocker/provision.sh
    sudo: unable to execute /tmp/grocker/provision.sh: Text file busy
    Removing intermediate container c066cb4a0128
    The command '/bin/sh -c sync; /bin/bash /tmp/grocker/provision.sh' returned a non-zero code: 1

Cf https://github.com/docker/docker/issues/9547 for corresponding issue
and its possible sync fix