### PR TITLE
Lip/osx upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .tox/
 .cache/
 build/

--- a/src/grocker/builders.py
+++ b/src/grocker/builders.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import contextlib
 import functools
+import itertools
 import io
 import json
 import logging
@@ -272,7 +273,8 @@ def inspect_stream(stream):
     """Return some data about the stream."""
     old_status = None
     data = {'success': True}
-    for line in (json.loads(six.smart_text(x)) for x in stream):
+    for line in itertools.chain.from_iterable(six.smart_text(x).splitlines() for x in stream):
+        line = json.loads(line)
         if 'status' in line:
             status = line['status']
             match = DIGEST_RE.match(status)


### PR DESCRIPTION
OSX docker client seems to return multilines lines : when iterating on stream, I got the following line : `'{"stream":" ---\\u003e 28a804e76bc7\\n"}\r\n{"stream":"Step 2 : LABEL grocker.image.kind builder\\n"}\r\n'`. This raises a `json.decoder.JSONDecodeError: Extra data` error.