### PR TITLE
Allow changing the default image name

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 4.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add ``--image-base-name`` option to allow customizing the generated image name
 
 
 4.3.2 (2016-11-09)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -13,8 +13,9 @@ Command line interface
     usage: grocker [-h] [-c CONFIG] [-r RUNTIME] [-e ENTRYPOINT_NAME]
                    [--volume VOLUMES] [--port PORTS] [--pip-conf <file>]
                    [--pip-constraint <file>] [--docker-image-prefix <url>]
-                   [-n <name>] [--result-file <filename>] [--no-check-version]
-                   [--purge {all,build,dangling,run}] [--version] [-v]
+                   [--image-base-name <name>] [-n <name>]
+                   [--result-file <filename>]
+                   [--purge {all,builders,dangling,runners}] [--version] [-v]
                    <action> [<action> ...] <release>
 
     positional arguments:
@@ -38,11 +39,14 @@ Command line interface
       --docker-image-prefix <url>
                             docker registry or account on Docker official registry
                             to use
+      --image-base-name <name>
+                            base name for the image (eg '<docker-image-prefix
+                            >/<image-base-name>:<image-version>')
       -n <name>, --image-name <name>
-                            name used to tag the build image.
+                            name used to tag the build image
       --result-file <filename>
                             yaml file where results (image name, ...) are written
-      --purge {all,build,dangling,run}
+      --purge {all,builders,dangling,runners}
       --version             show program's version number and exit
       -v, --verbose         verbose mode
 
@@ -98,6 +102,7 @@ It is written in YAML. By default, Grocker looks for this file in the current di
     repositories: {}
     dependencies: []
     docker_image_prefix: # optional
+    image_base_name: # optional
     entrypoint_name: grocker-runner
 
 Dependencies

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -223,5 +223,6 @@ def main():
         with io.open(args.result_file, 'w') as fp:
             yaml.dump(results, fp, indent=True)
 
+
 if __name__ == '__main__':
     main()

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -60,7 +60,7 @@ def arg_parser():
     )
     parser.add_argument(  # precedence
         '--port', action='append', default=[], dest='ports',
-        help="Port on which a container will listen for connections"
+        help="Port on which a container will listen for connections",
     )
     parser.add_argument(
         '--pip-conf', metavar='<file>', type=file_path_or_none_type, default=None,
@@ -72,17 +72,17 @@ def arg_parser():
     )
     parser.add_argument(
         '--docker-image-prefix', metavar='<url>',
-        help='docker registry or account on Docker official registry to use'
+        help='docker registry or account on Docker official registry to use',
     )
     parser.add_argument('-n', '--image-name', metavar='<name>', help="name used to tag the build image")
     parser.add_argument(
         'actions', choices=GrockerActions, type=GrockerActions, nargs='+',
-        metavar='<action>', help='should be one of {}'.format(', '.join(x.value for x in GrockerActions))
+        metavar='<action>', help='should be one of {}'.format(', '.join(x.value for x in GrockerActions)),
     )
 
     parser.add_argument(
         '--result-file', metavar='<filename>', default=None,
-        help="yaml file where results (image name, ...) are written"
+        help="yaml file where results (image name, ...) are written",
     )
     parser.add_argument('release', metavar='<release>', help="application to build (you can use version specifier)")
 

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -74,6 +74,10 @@ def arg_parser():
         '--docker-image-prefix', metavar='<url>',
         help='docker registry or account on Docker official registry to use',
     )
+    parser.add_argument(
+        '--image-base-name', metavar='<name>',
+        help="base name for the image (eg '<docker-image-prefix>/<image-base-name>:<image-version>')",
+    )
     parser.add_argument('-n', '--image-name', metavar='<name>', help="name used to tag the build image")
     parser.add_argument(
         'actions', choices=GrockerActions, type=GrockerActions, nargs='+',
@@ -158,6 +162,7 @@ def main():
         entrypoint_name=args.entrypoint_name,
         pip_constraint=args.pip_constraint,
         docker_image_prefix=args.docker_image_prefix,
+        image_base_name=args.image_base_name,
         volumes=args.volumes,
         ports=args.ports,
     )
@@ -171,7 +176,7 @@ def main():
         raise RuntimeError('Unknown runtime: %s', config['runtime'])
 
     docker_client = builders.docker_get_client()
-    image_name = args.image_name or helpers.default_image_name(config['docker_image_prefix'], args.release)
+    image_name = args.image_name or helpers.default_image_name(config, args.release)
     results = {
         'release': args.release,
         'image': image_name,

--- a/src/grocker/helpers.py
+++ b/src/grocker/helpers.py
@@ -142,12 +142,20 @@ def render_template(template_path, output_path, context):
         output_file.write(output)
 
 
-def default_image_name(docker_image_prefix, release):
+def default_image_name(config, release):
     req = pkg_resources.Requirement.parse(release)
     assert str(req.specifier).startswith('=='), "Only fixed version can use default image name."
-    img_name = "{project}{extra_requirements}:{project_version}-{grocker_version}".format(
-        project=req.project_name,
-        extra_requirements='-' + '-'.join(req.extras) if req.extras else '',
+    docker_image_prefix = config['docker_image_prefix']
+    if config['image_base_name']:
+        img_name = config['image_base_name']
+    elif req.extras:
+        img_name = "{project}-{extra_requirements}".format(
+            project=req.project_name,
+            extra_requirements='-'.join(req.extras),
+        )
+    else:
+        img_name = req.project_name
+    img_name += ":{project_version}-{grocker_version}".format(
         project_version=str(req.specifier)[2:],
         grocker_version=__version__,
     )

--- a/src/grocker/resources/grocker.yaml
+++ b/src/grocker/resources/grocker.yaml
@@ -40,4 +40,5 @@ ports: []
 repositories: {}  # {<repository name>: {uri: '<deb line>', key: '<PGP key for this repository>'}}
 dependencies: []
 docker_image_prefix:
+image_base_name:
 entrypoint_name: grocker-runner

--- a/tests/resources/grocker-test-project/gtp/__main__.py
+++ b/tests/resources/grocker-test-project/gtp/__main__.py
@@ -37,5 +37,6 @@ def custom():
     msg = identity(sys.argv[1] if len(sys.argv) > 1 else 'Missing parameter !')
     print('custom: %s' % msg)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Unless one fully specifies the image name (eg: 'registry/name-version'),
grocker will automatically generate a name based on:
 * package name and version
 * grocker version
 * whether extra deps are specified
 * docker registry prefix

This patch introduces an option (both through the cli and the config
file) to keep most of the current logic as-is and allow setting the base
name.