### PR TITLE
Fix whoami equality checks in runner provision

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 4.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix shell equality test
 
 
 4.5 (2016-12-19)

--- a/src/grocker/resources/docker/runner-image/provision.sh
+++ b/src/grocker/resources/docker/runner-image/provision.sh
@@ -30,7 +30,7 @@ setup_venv() {  # venv runtime *dependencies
 run_as_user() {  # script_or_function
     local script_or_function
     script_or_function="$*"
-    if [ "$(whoami)" == ${GROCKER_USER} ]; then
+    if [ "$(whoami)" = ${GROCKER_USER} ]; then
         ${script_or_function}
     else
         chmod -R go+rX ${WORKING_DIR}  # Allow non-root user to use file in grocker temporary directory
@@ -44,7 +44,7 @@ run_as_user() {  # script_or_function
 only_run_as_root() {  # script_or_function
     local script_or_function
     script_or_function="$*"
-    if [ "$(whoami)" == 'root' ]; then
+    if [ "$(whoami)" = 'root' ]; then
         ${script_or_function}
     fi
 }


### PR DESCRIPTION
On debian, with `sh`:

```
# if [ 'e' == 'e' ]; then
> echo toto
> fi
sh: 20: [: e: unexpected operator
# if [ 'e' = 'e' ]; then
> echo toto
> fi
toto
```
