### PR TITLE
Simple refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 #services:
 #  - docker
 before_install:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,11 +1,11 @@
 ChangeLog
 =========
 
-4.7 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Add support for Python 3.6
-
+- Drop obsolete .grocker file
 
 4.6 (2016-12-22)
 ----------------
@@ -13,7 +13,6 @@ ChangeLog
 - Fix shell equality test
 - Disable useless pip cache
 - Stop using sudo in compiler script
-
 
 4.5 (2016-12-19)
 ----------------

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 4.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for Python 3.6
 
 
 4.6 (2016-12-22)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Build Tools',
         'Topic :: System :: Software Distribution',
     ],

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -19,6 +19,7 @@ from . import __version__
 from . import builders
 from . import helpers
 from . import loggers
+from . import utils
 
 
 class GrockerActions(enum.Enum):
@@ -33,7 +34,7 @@ def arg_parser():
     Create an CLI args parser
 
     Some default value (marked as #precedence) are set to None due to precedence
-    order (see parse_config() doc string for more information).
+    order (see utils.parse_config() doc string for more information).
     """
     def file_path_type(x):
         return os.path.abspath(os.path.expanduser(x))
@@ -114,30 +115,6 @@ class PurgeAction(argparse.Action):
         parser.exit()
 
 
-def parse_config(config_paths, **kwargs):
-    """
-    Generate config regarding precedence order
-
-    Precedence order is defined as :
-
-    1. Command line arguments
-    2. project ``.grocker.yml`` file (or the one specified on the command line)
-    3. the grocker ``resources/grocker.yaml`` file
-    """
-    config = helpers.load_yaml_resource('resources/grocker.yaml')
-
-    if not config_paths and os.path.exists('.grocker.yml'):
-        config_paths = ['.grocker.yml']
-
-    for config_path in config_paths:
-        project_config = helpers.load_yaml(config_path)
-        config.update(project_config or {})
-
-    config.update({k: v for k, v in kwargs.items() if v})
-
-    return config
-
-
 def clean_actions(actions):
     if GrockerActions.all in actions:
         actions_without_all = set(GrockerActions) - {GrockerActions.all}
@@ -156,7 +133,7 @@ def clean_actions(actions):
 def main():
     parser = arg_parser()
     args = parser.parse_args()
-    config = parse_config(
+    config = utils.parse_config(
         args.config,
         runtime=args.runtime,
         entrypoint_name=args.entrypoint_name,
@@ -176,7 +153,7 @@ def main():
         raise RuntimeError('Unknown runtime: %s', config['runtime'])
 
     docker_client = builders.docker_get_client()
-    image_name = args.image_name or helpers.default_image_name(config, args.release)
+    image_name = args.image_name or utils.default_image_name(config, args.release)
     results = {
         'release': args.release,
         'image': image_name,
@@ -184,7 +161,7 @@ def main():
 
     wheels_volume_name = 'grocker-wheels-cache-{version}-{hash}'.format(
         version=__version__,
-        hash=helpers.config_identifier(config),
+        hash=utils.config_identifier(config),
     )
 
     if GrockerActions.build_dep in args.actions:

--- a/src/grocker/builders.py
+++ b/src/grocker/builders.py
@@ -157,17 +157,6 @@ def build_runner_image(
                 },
             )
 
-            # TODO(fbochu): .grocker file will be obsolete in next major version, so drop it.
-            helpers.render_template(
-                os.path.join(build_dir, '.grocker.j2'),
-                os.path.join(build_dir, '.grocker'),
-                {
-                    'grocker_version': __version__,
-                    'runtime': config['runtime'],
-                    'release': release,
-                },
-            )
-
             if config['pip_constraint']:
                 with io.open(config['pip_constraint'], 'r') as fp:
                     with io.open(os.path.join(build_dir, 'constraints.txt'), 'w') as f:

--- a/src/grocker/builders.py
+++ b/src/grocker/builders.py
@@ -24,6 +24,7 @@ from packaging import requirements
 from . import __version__, DOCKER_API_VERSION
 from . import six
 from . import helpers
+from . import utils
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ def build_root_image(docker_client, config, tag=None):
             {'repositories': config['repositories']},
         )
 
-        dependencies = helpers.get_dependencies(config)
+        dependencies = utils.get_dependencies(config)
         build_env = {'SYSTEM_DEPS': ' '.join(dependencies)}
         return docker_build_image(docker_client, build_dir, tag=tag, buildargs=build_env)
 
@@ -71,7 +72,7 @@ def build_compiler_image(docker_client, root_image_tag, config, tag=None):
             },
         )
 
-        dependencies = helpers.get_dependencies(config, with_build_dependencies=True)
+        dependencies = utils.get_dependencies(config, with_build_dependencies=True)
         with io.open(os.path.join(build_dir, 'provision.env'), 'w') as fp:
             fp.write('SYSTEM_DEPS="{}"'.format(' '.join(dependencies)))
 
@@ -175,7 +176,7 @@ def get_root_image(docker_client, config):
     img_name = 'grocker-{runtime}-root:{version}-{hash}'.format(
         runtime=config['runtime'],
         version=__version__,
-        hash=helpers.config_identifier(config),
+        hash=utils.config_identifier(config),
     )
     return docker_get_or_build_image(
         docker_client,
@@ -189,7 +190,7 @@ def get_compiler_image(docker_client, config):
     img_name = 'grocker-{runtime}-compiler:{version}-{hash}'.format(
         runtime=config['runtime'],
         version=__version__,
-        hash=helpers.config_identifier(config),
+        hash=utils.config_identifier(config),
     )
     root_tag = get_root_image(docker_client, config)
     return docker_get_or_build_image(

--- a/src/grocker/resources/docker/runner-image/.grocker.j2
+++ b/src/grocker/resources/docker/runner-image/.grocker.j2
@@ -1,4 +1,0 @@
-# obsolete, use GROCKER_* env vars instead
-version: {{ grocker_version }}
-runtime: {{ runtime }}
-release: {{ release }}

--- a/src/grocker/resources/docker/runner-image/provision.sh
+++ b/src/grocker/resources/docker/runner-image/provision.sh
@@ -59,10 +59,6 @@ system_provision() {
     local sys_config_dir
     sys_config_dir=/home/grocker/sys.cfg
 
-    # TODO(fbochu): .grocker file will be obsolete in next major version, so drop it.
-    # install Grocker config file
-    install --owner=grocker --mode=0444 /tmp/grocker/.grocker ~grocker/.grocker
-
     # Allow ssmtp configuration
     rm /etc/ssmtp/ssmtp.conf
     ln -s ${sys_config_dir}/ssmtp.conf /etc/ssmtp/ssmtp.conf

--- a/src/grocker/utils.py
+++ b/src/grocker/utils.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Polyconseil SAS. All rights reserved.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import hashlib
+import itertools
+import os.path
+
+import pkg_resources
+
+from . import __version__
+from . import helpers
+
+GROUP_SEPARATOR = b'\x1D'
+RECORD_SEPARATOR = b'\x1E'
+UNIT_SEPARATOR = b'\x1F'
+
+
+def config_identifier(config):
+    """
+    Hash config to get an unique identifier
+
+    Args:
+        config (dict): Grocker config
+
+    Returns:
+        str: Config identifier (SHA 256)
+    """
+    def unit_list(l):
+        return UNIT_SEPARATOR.join(sorted(x.encode('utf-8') for x in l))
+
+    dependencies = unit_list(get_dependencies(config, with_build_dependencies=True))
+    repositories = RECORD_SEPARATOR.join(
+        unit_list([name] + [cfg[x] for x in sorted(cfg)])
+        for name, cfg in config['repositories'].items()
+    )
+    data = GROUP_SEPARATOR.join([
+        dependencies,
+        repositories,
+    ])
+    digest = hashlib.sha256(data)
+    return digest.hexdigest()
+
+
+def default_image_name(config, release):
+    req = pkg_resources.Requirement.parse(release)
+    assert str(req.specifier).startswith('=='), "Only fixed version can use default image name."
+    docker_image_prefix = config['docker_image_prefix']
+    if config['image_base_name']:
+        img_name = config['image_base_name']
+    elif req.extras:
+        img_name = "{project}-{extra_requirements}".format(
+            project=req.project_name,
+            extra_requirements='-'.join(req.extras),
+        )
+    else:
+        img_name = req.project_name
+    img_name += ":{project_version}-{grocker_version}".format(
+        project_version=str(req.specifier)[2:],
+        grocker_version=__version__,
+    )
+    return '/'.join((docker_image_prefix, img_name)) if docker_image_prefix else img_name
+
+
+def get_run_dependencies(dependency_list):
+    """
+    Parse list of dependencies to only get run dependencies.
+
+    Dependency list is a list of string or dict, which match the following
+    format:
+
+     [
+        'run_dependency_1',
+        {'run_dependency_2': 'build_dependency_2'},
+        {'run_dependency_3': ['build_dependency_3.1', 'build_dependency_3.2']},
+    ]
+    """
+    for dependency in dependency_list:
+        if isinstance(dependency, dict):
+            for key in dependency:
+                yield key
+        else:
+            yield dependency
+
+
+def get_build_dependencies(dependency_list):
+    """
+    Parse list of dependencies to only get build dependencies
+
+    see get_run_dependencies() for dependency list format
+    """
+    for dependency in dependency_list:
+        if isinstance(dependency, dict):
+            for value_or_list in dependency.values():
+                if isinstance(value_or_list, list):
+                    for value in value_or_list:
+                        yield value
+                else:
+                    yield value_or_list
+        else:
+            yield dependency
+
+
+def get_dependencies(config, with_build_dependencies=False):
+    runtime_dependencies = config['system']['runtime'][config['runtime']]
+
+    dependencies = itertools.chain(
+        config['system']['base'],
+        get_run_dependencies(runtime_dependencies),
+        get_run_dependencies(config['dependencies'])
+    )
+
+    if with_build_dependencies:
+        build_dependencies = itertools.chain(
+            config['system']['build'],
+            get_build_dependencies(runtime_dependencies),
+            get_build_dependencies(config['dependencies'])
+        )
+
+        dependencies = itertools.chain(dependencies, build_dependencies)
+
+    return list(dependencies)
+
+
+def parse_config(config_paths, **kwargs):
+    """
+    Generate config regarding precedence order
+
+    Precedence order is defined as :
+
+    1. Command line arguments
+    2. project ``.grocker.yml`` file (or the one specified on the command line)
+    3. the grocker ``resources/grocker.yaml`` file
+    """
+    config = helpers.load_yaml_resource('resources/grocker.yaml')
+
+    if not config_paths and os.path.exists('.grocker.yml'):
+        config_paths = ['.grocker.yml']
+
+    for config_path in config_paths:
+        project_config = helpers.load_yaml(config_path)
+        config.update(project_config or {})
+
+    config.update({k: v for k, v in kwargs.items() if v})
+
+    return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,8 +11,8 @@ import unittest
 import itertools
 
 from grocker import __version__
-from grocker.__main__ import parse_config
-from grocker.helpers import default_image_name
+from grocker.utils import parse_config
+from grocker.utils import default_image_name
 import grocker.six as grocker_six
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, docs, quality
+envlist = py27, py34, py35, py36, docs, quality
 skip_missing_interpreters = True
 
 [testenv:docs]


### PR DESCRIPTION
- Support for Python 3.6
- Drop obsolete ``.grocker`` file
- Split helpers and utils