### PR TITLE
Retrive image manifest hash

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ ChangeLog
 ----------------
 
 - Support of pip trusted host config in wheel builder.
+- Retrieve image manifest digest from registry.
 
 
 5.2 (2017-07-18)

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -134,7 +134,10 @@ def build(release, build_dependencies, build_image, push, **kwargs):
         else:
             logger.info('Pushing image...')
             image = builders.docker_push_image(docker_client, image_name)
-            collect['hash'] = [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
+            collect['hash'] = (
+                builders.get_manifest_digest(image_name)
+                or [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
+            )
 
     if kwargs['result_file']:
         helpers.dump_yaml(kwargs['result_file'], collect)

--- a/src/grocker/builders/__init__.py
+++ b/src/grocker/builders/__init__.py
@@ -7,7 +7,7 @@ from . import build
 from .build import build_runner_image
 from . import naming
 from . import op
-from .op import docker_push_image, is_prefixed_image
+from .op import docker_push_image, get_manifest_digest, is_prefixed_image
 from .wheels import compile_wheels
 
 
@@ -16,6 +16,7 @@ __all__ = [
     'docker_push_image',
     'is_prefixed_image',
     'compile_wheels',
+    'get_manifest_digest',
     'get_or_build_root_image',
     'get_or_build_compiler_image',
 ]

--- a/src/grocker/builders/op.py
+++ b/src/grocker/builders/op.py
@@ -11,6 +11,8 @@ import docker
 import docker.errors
 import docker.utils.json_stream
 
+import requests
+
 from .. import __version__
 from .. import helpers
 from .. import six
@@ -86,6 +88,16 @@ def docker_push_image(docker_client, name):
     logger.info('Pushing image %s...', name)
     docker_client.images.push(name)
     return docker_client.images.get(name)
+
+
+def get_manifest_digest(name):
+    registry_repository, tag = name.split(':', 1)
+    if '.' not in registry_repository:  # Docker Hub
+        return None  # Docker HUB API is not documented
+
+    registry, repository = registry_repository.split('/', 1)
+    response = requests.head('https://{}/v2/{}/manifests/{}'.format(registry, repository, tag))
+    return response.headers['Docker-Content-Digest']
 
 
 def docker_run_container(docker_client, name, command, volumes=None, environment=None):


### PR DESCRIPTION
Since at least Docker registry 2.6.0 the image digest and the manifest
digest differ. The Grocker result file give the digest to allow checking
it during the pull process. With the new registry this always fail.

For private registry, we now retrieve the manifest digest using the http
API to fix this issue.