### PR TITLE
compile: delay setuptools installation in virtualenv

### DIFF
--- a/src/grocker/resources/docker/compiler-image/compile.py
+++ b/src/grocker/resources/docker/compiler-image/compile.py
@@ -70,7 +70,11 @@ def setup_venv(python):
     """Setup venv and return python interpreter."""
     info('Setup venv using %s...', python)
     venv = tempfile.mkdtemp(suffix='.venv')
-    subprocess.check_call([python, '-m', 'virtualenv', '-p', python, venv])
+    try:
+        # python 3
+        subprocess.check_call([python, '-m', 'venv', '-p', python, venv])
+    except subprocess.CalledProcessError:
+        subprocess.check_call([python, '-m', 'virtualenv', venv])
     subprocess.check_call([os.path.join(venv, 'bin', 'pip'), 'install', '-U', 'pip', 'setuptools', 'wheel'])
     return venv
 


### PR DESCRIPTION
virtualenv will try to pip install pkg_resources and this can fail.
This is an extract of the virtualenv.py file contained in the image:

    if not no_setuptools:
        to_install.append('setuptools')
        to_install.append('pkg_resources')