### PR TITLE
Simplify dependency declaration

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 5.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Simplify dependency declaration (**breaking change**)
 
 
 5.4 (2017-10-12)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -88,7 +88,9 @@ It is written in YAML. By default, Grocker looks for this file in the current di
     volumes: []
     ports: []
     repositories: {}
-    dependencies: []
+    dependencies:
+        run: []
+        build: []
     docker_image_prefix: # optional
     image_base_name: # optional
     entrypoint_name: grocker-runner
@@ -96,12 +98,10 @@ It is written in YAML. By default, Grocker looks for this file in the current di
 Dependencies
 ~~~~~~~~~~~~
 
-Each entry of the  ``dependencies`` list follow one of this syntax:
+Two kind of dependencies can be declared those used on the final image (``run``) and
+those which will be installed only on the build image (``build``).
 
-- ``my-dependency``, for runtime only dependencies (no build dependency)
-- ``my-dependency: my-dependency-dev``, for runtime dependencies with one build dependency
-- ``my-dependency: [my-dependency-dev, my-dependency-dev2]``, for runtime dependencies
-  with more than one build dependencies
+Each package declared on those lists will be installed using the system package manager.
 
 Repositories
 ~~~~~~~~~~~~
@@ -158,11 +158,18 @@ An example with all options customised:
                 =A015
                 -----END PGP PUBLIC KEY BLOCK-----
     dependencies:
-        - libzbar0: libzbar-dev
-        - libjpeg62-turbo: libjpeg62-turbo-dev
-        - libffi6: libffi-dev
-        - libtiff5: libtiff5-dev
-        - nginx
+        run:
+            - libzbar0
+            - libjpeg62-turbo
+            - libffi6
+            - libtiff5
+            - nginx
+        build:
+            - libzbar-dev
+            - libjpeg62-turbo-dev
+            - libffi-dev
+            - libtiff5-dev
+
     docker_image_prefix: docker.example.com
     entrypoint_name: my-runner
 

--- a/src/grocker/resources/grocker.yaml
+++ b/src/grocker/resources/grocker.yaml
@@ -7,26 +7,24 @@
 
 system:  # grocker internal configuration
   image: debian:jessie  # base image to use to build root image
-
-  base:  # dependencies installed on root image
-    - less
-    - netcat-traditional
-    - vim
-
-  build:  # dependencies installed on build image
-    - build-essential
-    - gettext
-    - nodejs-legacy
-
   runtime:  # dependencies needed for specified runtime
     python2.7:
-      - python: python-dev
-      - libpython2.7
-      - python-virtualenv
+      run:
+        - python
+        - libpython2.7
+        - python-virtualenv
+      build:
+        - build-essential
+        - python-dev
+
     python3.4:
-      - python3: python3-dev
-      - libpython3.4
-      - python3-venv
+      run:
+        - python3
+        - libpython3.4
+        - python3-venv
+      build:
+        - build-essential
+        - python3-dev
 
 # There begin the project configuration (so all values below are use as default)
 
@@ -35,7 +33,9 @@ pip_constraint: # pip_constraint is optional
 volumes: []
 ports: []
 repositories: {}  # {<repository name>: {uri: '<deb line>', key: '<PGP key for this repository>'}}
-dependencies: []
+dependencies:
+  run: []
+  build: []
 docker_image_prefix:
 image_base_name:
 entrypoint_name: grocker-runner

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -47,12 +47,7 @@ def docker_inspect(image):
 
 
 class AbstractBuildTestCase(unittest.TestCase):
-    dependencies = yaml.safe_load("""
-        - libzbar0: libzbar-dev
-        - libjpeg62-turbo: libjpeg62-turbo-dev
-        - libffi6: libffi-dev
-        - libtiff5: libtiff5-dev
-    """)
+    dependencies = {}
     runtime = None
 
     def run_grocker(self, release, command, cwd, docker_prefix):
@@ -110,6 +105,10 @@ class AbstractBuildTestCase(unittest.TestCase):
 
 
 class BuildTestCase(AbstractBuildTestCase):
+    dependencies = {
+        'build': ['libzbar-dev', 'libjpeg62-turbo-dev', 'libffi-dev', 'libtiff5-dev'],
+        'run': ['libzbar0', 'libjpeg62-turbo', 'libffi6', 'libtiff5'],
+    }
 
     def test_dependencies(self):
         config = {
@@ -215,20 +214,19 @@ class BuildCustomRuntimeTestCase(BuildTestCase):
 
 class AlpineTestCase(AbstractBuildTestCase):
     runtime = 'python2.7'
-    dependencies = []
 
     def test_with_alpine(self):
         config = {
             'system': {
                 'image': 'alpine',
-                'base': [],
-                'build': [],
                 'runtime': {
-                    'python2.7': [
-                        'python2',
-                        'py2-pip',
-                        'py-virtualenv',
-                    ],
+                    'python2.7': {
+                        'run': [
+                            'python2',
+                            'py2-pip',
+                            'py-virtualenv',
+                        ],
+                    },
                 },
             },
             'entrypoint_name': '/bin/sh'


### PR DESCRIPTION
The old way to declare dependencies was not very useful and can be
misleading (`[{libA: libB-dev}, libA]`). Using two lists, one for the
run dependencies and one for the build dependencies, is simpler.