### PR TITLE
Add support for Python's stretch+3.6 docker image

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 6.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for Python's stretch+3.6 docker image.
 
 
 6.2.1 (2018-04-16)

--- a/src/grocker/resources/grocker.yaml
+++ b/src/grocker/resources/grocker.yaml
@@ -54,6 +54,15 @@ runtimes:  # grocker internal configuration
         - build-essential
         - python3-dev
 
+  "stretch/3.6":
+    # TODO: this is a rolling-release tag, so the root image needs to be updated to
+    # grab the latest upstream image.
+    image: python:3.6-slim-stretch
+    runtime: python3
+    dependencies:
+      build:
+        - build-essential
+
 # There begin the project configuration (so all values below are use as default)
 
 runtime: alpine/3.6

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -235,6 +235,10 @@ class DebianBuildTestCase(AbstractBuildTestCase, unittest.TestCase):
         self.check(config, '{}=={}'.format(self.tp_name, self.tp_version), ['-c', script], 'True')
 
 
+class DebianPython36BuildTestCase(DebianBuildTestCase):
+    runtime = 'stretch/3.6'
+
+
 class AlpineTestCase(AbstractBuildTestCase, unittest.TestCase):
     runtime = 'alpine/3.6'
     dependencies = {


### PR DESCRIPTION
Uses Python's official docker images from https://hub.docker.com/_/python/