### PR TITLE
Replace "+" by "-" in default_image_name to get valid docker tag

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 6.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace "+" signs in python versions by "-" in default image name
 
 
 6.4 (2018-11-28)

--- a/src/grocker/utils.py
+++ b/src/grocker/utils.py
@@ -57,7 +57,10 @@ def default_image_name(config, req):
     else:
         img_name = req.project_name
     img_name += ":{project_version}".format(
-        project_version=req.version,
+        # Python versions might contain "+"
+        # but a docker tag name must be valid ASCII and may contain lowercase and uppercase
+        # letters, digits, underscores, periods and dashes
+        project_version=req.version.replace('+', '-'),
     )
     return '/'.join((docker_image_prefix, img_name)) if docker_image_prefix else img_name
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,6 +148,7 @@ class DefaultImageNameTestCase(unittest.TestCase):
             releases = (
                 'grocker-test-project==2.0.0',
                 'grocker-test-project[pep8]==2.0.0',
+                'grocker-test-project[pep8, other_extra]==2.0.0+git1234',
                 filepath,
             )
             image_names = (None, 'demo-app')
@@ -164,6 +165,11 @@ class DefaultImageNameTestCase(unittest.TestCase):
                 'registry.local/grocker-test-project-pep8:2.0.0',
                 'demo-app:2.0.0',
                 'registry.local/demo-app:2.0.0',
+                # with several extras and + sign
+                'grocker-test-project-other_extra-pep8:2.0.0-git1234',
+                'registry.local/grocker-test-project-other_extra-pep8:2.0.0-git1234',
+                'demo-app:2.0.0-git1234',
+                'registry.local/demo-app:2.0.0-git1234',
                 # from path
                 'grocker-test-project:1.2.3',
                 'registry.local/grocker-test-project:1.2.3',


### PR DESCRIPTION
"+" are valid in Python versions according to PEP 440 but docker
tags must be valid ASCII and may contain lowercase and uppercase
letters, digits, underscores, periods and dashes