### PR TITLE
setup: fix distutils.index-servers to `pypi`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,3 +67,6 @@ universal = true
 
 [zest.releaser]
 create-wheel = yes
+
+[distutils]
+index-servers = pypi


### PR DESCRIPTION
This avoids zest upload on test or private indexes by default.

Directly inspired from https://github.com/Polyconseil/django-mds/commit/b331f5b00309ffd6ba63a5493df5b68f0d3e6423 :)