### PR TITLE
builders: Use extra requirement when building from a wheel filepath

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,7 @@ ChangeLog
 6.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix pip install error when building an image from a wheel with extra requirements passed from a filepath
 
 
 6.6 (2019-01-18)

--- a/Readme.rst
+++ b/Readme.rst
@@ -30,9 +30,10 @@ Direct wheel path
 A wheel can also be directly passed to grocker to avoid the need to upload an artefact to
 build an image.
 
-Grocker will switch to this mode if a ``/`` is present in the argument.
+Grocker will switch to this mode if a ``/`` is present in the argument. Pip ``extra``
+requirements can be used in this mode.
 
 .. code-block:: console
 
-    $ grocker build ./path/to/ipython-7.1.1-py3-none-any.whl --entrypoint ipython
-    $ docker run --rm -ti ipython:7.1.1-<grocker-version>
+    $ grocker build ./path/to/ipython-7.1.1-py3-none-any.whl[doc] --entrypoint ipython
+    $ docker run --rm -ti ipython-doc:7.1.1-<grocker-version>

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -25,7 +25,15 @@ The build command line interface
 
     Usage: grocker build [OPTIONS] RELEASE
 
-      Build docker image for <release> (version specifiers can be used).
+      Build docker image for RELEASE (version specifiers can be used).
+
+      RELEASE can either be the name of a project, or the path to a wheel to
+      use. In both cases, extra requirements can be applied:
+
+      grocker build your_project[with_extra]==1.2.3
+
+      grocker build /path/to/your_project-1.2.3.whl[with_extra]
+
 
     Options:
       -c, --config <filename>         Grocker config file

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -82,7 +82,15 @@ def purge(all_versions, including_final_images):
 )
 @click.argument('release')
 def build(release, build_dependencies, build_image, push, **kwargs):
-    """Build docker image for <release> (version specifiers can be used)."""
+    """Build docker image for RELEASE (version specifiers can be used).
+
+    RELEASE can either be the name of a project, or the path to a wheel to use. In both cases, extra requirements can be
+    applied:
+
+        grocker build your_project[with_extra]==1.2.3
+
+        grocker build /path/to/your_project-1.2.3.whl[with_extra]
+    """
     requirement = utils.GrockerRequirement.parse(release)
     collect = {}  # will contain all collected information
     docker_client = utils.docker_get_client()

--- a/src/grocker/builders/wheels.py
+++ b/src/grocker/builders/wheels.py
@@ -58,10 +58,12 @@ def compile_wheels(docker_client, config, requirement, pip_conf):
             'mode': 'rw',
         },
     }
+
     if requirement.filepath:
         filename = os.path.basename(requirement.filepath)
-        to_install = '/tmp/src/{}'.format(filename)  # noqa: S108
-        volumes[requirement.filepath] = {'bind': to_install, 'mode': 'ro'}
+        wheel_path = '/tmp/src/{}'.format(filename)  # noqa: S108
+        volumes[requirement.filepath] = {'bind': wheel_path, 'mode': 'ro'}
+        to_install = wheel_path + requirement.pip_extras
     else:
         to_install = requirement.to_install
 

--- a/src/grocker/resources/docker/compiler-image/compile.py
+++ b/src/grocker/resources/docker/compiler-image/compile.py
@@ -17,7 +17,7 @@ import zlib
 try:  # Python 3+
     import configparser
 except ImportError:  # Python 2.7
-    import ConfigParser as configparser
+    import ConfigParser as configparser  # noqa: N813
 
 
 WHEELS_DIRECTORY = os.path.expanduser('~/packages')

--- a/src/grocker/utils.py
+++ b/src/grocker/utils.py
@@ -176,9 +176,11 @@ class GrockerRequirement(object):
         )
 
     @property
+    def pip_extras(self):
+        if not self.extras:
+            return ''
+        return "[{}]".format(",".join(sorted(self.extras)))
+
+    @property
     def to_install(self):
-        parts = [self.project_name]
-        if self.extras:
-            parts.append("[{}]".format(",".join(sorted(self.extras))))
-        parts.extend([self.operator, self.version])
-        return "".join(parts)
+        return "".join([self.project_name, self.pip_extras, self.operator, self.version])

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -138,6 +138,28 @@ class AbstractBuildTestCase:
         expected = msg
         self.check(config, wheel_filepath, msg, expected)
 
+    def test_from_path_with_extra(self):
+        test_project_path = os.path.abspath(os.path.join(__file__, '..', 'resources', 'grocker-test-project'))
+        subprocess.check_call([  # noqa: S603
+                sys.executable,
+                'setup.py',
+                'bdist_wheel',
+                '--universal',
+            ],
+            cwd=test_project_path,
+        )
+        # Specificy [pep8] extra requirement
+        wheel_filepath = os.path.join(
+            test_project_path, 'dist', 'grocker_test_project-3.0.1-py2.py3-none-any.whl[pep8]',
+        )
+        config = {
+            'runtime': self.runtime,
+            'dependencies': self.dependencies,
+        }
+        msg = 'Grocker build this successfully !'
+        expected = msg
+        self.check(config, wheel_filepath, msg, expected)
+
     def test_pip_constraints(self):
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(b'qrcode==5.2')


### PR DESCRIPTION
Commit 7dd124c0c9dc7c47ff57e722228b4c4373a3e6a3 introduced a way to pass
a wheel path as a release argument. However, it ignored the extra
requirements that could be provided with it, e.g.:

    /path/to/grocker_test_project-3.0.1-py2.py3-none-any.whl[pep8]

This commit introduces a new GrockerRequirement property `pip_extras`
which returns the extras ready to be passed to pip (e.g.: '[pep8]'). The
property is used to fix grocker.builders.compile_wheels.