### PR TITLE
builders: explicit error on Docker registry error

### DIFF
--- a/src/grocker/builders/op.py
+++ b/src/grocker/builders/op.py
@@ -99,6 +99,7 @@ def get_manifest_digest(name):
 
     registry, repository = registry_repository.split('/', 1)
     response = requests.head('https://{}/v2/{}/manifests/{}'.format(registry, repository, tag))
+    response.raise_for_status()
     return response.headers['Docker-Content-Digest']
 
 


### PR DESCRIPTION
We wouldn't know about the request error but instead it would fail on the next line:
```
KeyError: 'docker-content-digest'
```