### PR TITLE
cli: drop python 2.7 support for grocker command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: required
 dist: xenial
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ ChangeLog
 6.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Drop Python 2.7 support (for Grocker command) **breaking change**
 
 
 6.8 (2019-11-18)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Natural Language :: English
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -27,6 +26,7 @@ classifiers =
 zip_safe = True
 include_package_data = True
 packages = find:
+python_requires = >=3.5
 setup_requires =
     setuptools
 install_requires =
@@ -38,7 +38,6 @@ install_requires =
     pip>=10
     pyyaml>=3.11
     packaging
-    enum34; python_version == '2.7'
 
 [options.packages.find]
 where = src

--- a/src/grocker/__init__.py
+++ b/src/grocker/__init__.py
@@ -17,8 +17,8 @@ class GrockerDeprecationWarning(Warning):
     pass
 
 
-if tuple(sys.version_info[:2]) in ((2, 7), (3, 4), (3, 5)):
+if tuple(sys.version_info[:2]) in ((3, 5)):
     warnings.warn(
-        "Support for 2.7, 3.4 and 3.5 will be dropped in next major version",
+        "Support for 3.5 will be dropped in next major version",
         category=GrockerDeprecationWarning,
     )

--- a/src/grocker/resources/docker/compiler-image/compile.py
+++ b/src/grocker/resources/docker/compiler-image/compile.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import argparse
 import base64
+import configparser
 import logging
 import logging.config
 import os
@@ -13,12 +14,6 @@ import os.path
 import subprocess  # noqa: S404
 import tempfile
 import zlib
-
-try:  # Python 3+
-    import configparser
-except ImportError:  # Python 2.7
-    import ConfigParser as configparser  # noqa: N813
-
 
 WHEELS_DIRECTORY = os.path.expanduser('~/packages')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, docs, quality
+envlist = py35, py36, py37, py38, docs, quality
 skip_missing_interpreters = True
 
 [testenv:docs]


### PR DESCRIPTION
Python is not supported upstream since 2020-01-01.