### PR TITLE
get_manifest is now optionnal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ ChangeLog
 ----------------
 
 - Drop Python 2.7 support (for Grocker command) **breaking change**
+- get image hash from manifest is now optionnal and set by default to False
 
 
 6.8 (2019-11-18)

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -154,7 +154,7 @@ def build(release, build_dependencies, build_image, push, **kwargs):
             collect['hash'] = (
                 builders.get_manifest_digest(image_name)
                 or [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
-            )
+            ) if config['manifest'] else [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
 
     if kwargs['result_file']:
         helpers.dump_yaml(kwargs['result_file'], collect)

--- a/src/grocker/resources/grocker.yaml
+++ b/src/grocker/resources/grocker.yaml
@@ -118,3 +118,4 @@ dependencies:
 docker_image_prefix:
 image_base_name:
 entrypoint_name: grocker-runner
+manifest: False

--- a/src/grocker/utils.py
+++ b/src/grocker/utils.py
@@ -29,8 +29,8 @@ def config_identifier(config):
         str: Config identifier (SHA 256)
 
     """
-    def unit_list(l):
-        return UNIT_SEPARATOR.join(sorted(x.encode('utf-8') for x in l))
+    def unit_list(list_item):
+        return UNIT_SEPARATOR.join(sorted(x.encode('utf-8') for x in list_item))
 
     dependencies = unit_list(get_dependencies(config, with_build_dependencies=True))
     repositories = RECORD_SEPARATOR.join(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -119,7 +119,8 @@ class AbstractBuildTestCase:
 
     def test_from_path(self):
         test_project_path = os.path.abspath(os.path.join(__file__, '..', 'resources', 'grocker-test-project'))
-        subprocess.check_call([  # noqa: S603
+        subprocess.check_call(  # noqa: S603
+            [
                 sys.executable,
                 'setup.py',
                 'bdist_wheel',
@@ -140,7 +141,8 @@ class AbstractBuildTestCase:
 
     def test_from_path_with_extra(self):
         test_project_path = os.path.abspath(os.path.join(__file__, '..', 'resources', 'grocker-test-project'))
-        subprocess.check_call([  # noqa: S603
+        subprocess.check_call(  # noqa: S603
+            [
                 sys.executable,
                 'setup.py',
                 'bdist_wheel',


### PR DESCRIPTION
paramètre pour rendre la récupération du manifest optionnel

authentification sur la requete https pour récupérer le manifeste
