### PR TITLE
optionnal image hash in docker push result file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ ChangeLog
 6.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- optionnal manifest set image hash to None
 
 
 6.9 (2021-04-13)

--- a/src/grocker/__main__.py
+++ b/src/grocker/__main__.py
@@ -154,7 +154,7 @@ def build(release, build_dependencies, build_image, push, **kwargs):
             collect['hash'] = (
                 builders.get_manifest_digest(image_name)
                 or [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
-            ) if config['manifest'] else [x.split('@')[1] for x in image.attrs['RepoDigests']][0]
+            ) if config['manifest'] else None
 
     if kwargs['result_file']:
         helpers.dump_yaml(kwargs['result_file'], collect)


### PR DESCRIPTION
adjustment with optionnal manifest info : 
setting hash to None is manifest option is not set